### PR TITLE
[TL] Adds MIT Licence attributing source to Myroslav Lisniak (as per…

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,22 @@
+The MIT License (MIT)
+
+Copyright (c) 2015 Myroslav Lisniak
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.
+


### PR DESCRIPTION
… http://choosealicense.com/licenses/mit/)

Hi Myroslav

I was hoping to use your gatling TCP extension for load testing in a project I'm working on at the moment. However, no license has been specified for your extension, and because the project I'm working will hopefully be released with an open-source licence, I am not able to use it. As per http://choosealicense.com/no-license/, with no license you retain all copyright and I can't include the source in my project.

I was wondering if you'd consider adopting an MIT licence for your extension as per this pull request (which just includes a LICENSE.md that is the default MIT licence attributing the copyright to you). 

[choosealicence.com](choosealicence.com) describes the MIT licence as 
*"The MIT License is a permissive license that is short and to the point. It lets people do anything they want with your code as long as they provide attribution back to you and don’t hold you liable."*

Best wishes,
Thorben Louw